### PR TITLE
投稿作成の際のユーザー情報の紐づけ

### DIFF
--- a/src/Components/PostForm/PostForm.tsx
+++ b/src/Components/PostForm/PostForm.tsx
@@ -85,7 +85,10 @@ export default function PostForm() {
 
       <input type="file" onChange={handleImageChange} />
 
-      <button onClick={handleUpload} disabled={!user}>
+      <button
+        onClick={handleUpload}
+        disabled={!user || user?.loginType === "Guest"}
+      >
         Upload
       </button>
 

--- a/src/Components/PostForm/PostForm.tsx
+++ b/src/Components/PostForm/PostForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { functionsEndpoint } from "@/app/firebase";
 import { uploadImage } from "@/utils/Uploader";
+import { useUser } from "@/utils/UserContext";
 import Box from "@mui/material/Box";
 import LinearProgress from "@mui/material/LinearProgress";
 import Typography from "@mui/material/Typography";
@@ -12,6 +13,7 @@ export default function PostForm() {
   const [text, setText] = useState<string>("");
   const [error, setError] = useState<string>("");
   const [progress, setProgress] = useState<number>(100);
+  const { user } = useUser();
 
   const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     const selectedFile = event.target.files?.[0];
@@ -40,7 +42,7 @@ export default function PostForm() {
         console.log("Generated storage path hash:", hash);
 
         const postData = {
-          userId: "temp", // authenticatorが準備できるまで仮で設定
+          userId: user ? user.uid : "",
           storeId: url, // トークン管理ができるまではurlをそのまま管理
           text: text,
           goalId: "temp", // authenticatorが準備できるまで仮で設定
@@ -83,7 +85,9 @@ export default function PostForm() {
 
       <input type="file" onChange={handleImageChange} />
 
-      <button onClick={handleUpload}>Upload</button>
+      <button onClick={handleUpload} disabled={!user}>
+        Upload
+      </button>
 
       {progress !== 100 && <LinearProgressWithLabel value={progress} />}
 


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [投稿作成機能とユーザー情報を紐づけ](https://github.com/MurakawaTakuya/todo-real/issues/54)

## 概要
<!-- 変更内容を簡単に説明 -->
投稿を作成する際のuserIdを、ログインしているアカウントのuserIdと同じになるようにした。
投稿のUploadボタンをログインしていないときとゲストログイン時には、押せないようにした。

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
<!--
- 変更1
  - 説明が必要なら記述
- 変更2
-->
user.uidでuserIdを取得し、三項演算子によって空白でなければuser.uidでidを送信するようにした。
投稿のUploadボタンをdisabledを使って、userがnullの時とゲストログインの時にtrueとなるように条件式を追加した。

|ログアウトおよびゲストログイン|ログイン時|
|-|-|
|![image](https://github.com/user-attachments/assets/032ed177-287b-459d-a626-11310b26f70a)|![image](https://github.com/user-attachments/assets/0e0cd92a-d774-40bc-a36d-550fa5e024a3)|



## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [x] PRに必要な内容を記述し、Assignやタイトルを設定した
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
