### PR TITLE
ログインしていない場合は/accountにリダイレクトする

### DIFF
--- a/src/Components/TopPage/TopPage.tsx
+++ b/src/Components/TopPage/TopPage.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useUser } from "@/utils/UserContext";
+import { redirect } from "next/navigation";
+import { ReactNode } from "react";
+
+interface TopPageProps {
+  children: ReactNode;
+}
+
+export const TopPage = ({ children }: TopPageProps) => {
+  const { user } = useUser();
+  if (user === null && window.location.pathname !== "/account/") {
+    redirect("/account");
+  }
+  return (
+    <>
+      {user === undefined ? (
+        <>ローディングぐるぐるしてるつもり</>
+      ) : (
+        <main>{children}</main>
+      )}
+    </>
+  );
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import Header from "@/Components/Header/Header";
+import { TopPage } from "@/Components/TopPage/TopPage";
 import "@/styles/globals.scss";
 import "@/utils/CloudMessaging/getNotification";
 import { UserProvider } from "@/utils/UserContext";
@@ -24,9 +25,9 @@ export default function RootLayout({
     <html lang="ja">
       <head></head>
       <body>
+        <Header />
         <UserProvider>
-          <Header />
-          <main>{children}</main>
+          <TopPage>{children}</TopPage>
         </UserProvider>
       </body>
     </html>

--- a/src/utils/UserContext.tsx
+++ b/src/utils/UserContext.tsx
@@ -12,13 +12,14 @@ import {
 import { fetchUserAPI } from "./fetchUserAPI";
 
 interface UserContextValue {
-  user: UserData | null;
-  setUser: React.Dispatch<React.SetStateAction<UserData | null>>;
+  user: UserData | null | undefined;
+  setUser: React.Dispatch<React.SetStateAction<UserData | null | undefined>>;
 }
 
-let globalSetUser: React.Dispatch<
-  React.SetStateAction<UserData | null>
-> | null = null;
+let globalSetUser:
+  | React.Dispatch<React.SetStateAction<UserData | null | undefined>>
+  | null
+  | undefined = undefined;
 
 export const UserContext = createContext<UserContextValue | undefined>(
   undefined
@@ -29,7 +30,7 @@ interface Props {
 }
 
 export const UserProvider = ({ children }: Props) => {
-  const [user, setUser] = useState<UserData | null>(null);
+  const [user, setUser] = useState<UserData | null | undefined>(undefined);
 
   globalSetUser = setUser;
 
@@ -98,6 +99,14 @@ export const UserProvider = ({ children }: Props) => {
 
     return () => unsubscribe();
   }, []);
+
+  console.log(
+    user === undefined
+      ? "ローディング中"
+      : user === null
+      ? "ログインしていません"
+      : user
+  );
 
   return (
     <UserContext.Provider value={{ user, setUser }}>


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [ログイン中のnullとログアウト状態のnullを分ける](https://github.com/MurakawaTakuya/todo-real/issues/74)

## 概要
<!-- 変更内容を簡単に説明 -->
ログインしていない場合は/accountにリダイレクトする

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- useUser()のuserの初期値をnullにしており、firebaseのcurrentUserの返り値でログインしていない場合はnullが返っていたため、ログイン情報取得中なのかログインしていないのかが判別できなかった。そこで初期値をundefinedとした
  - 重要な話 -> [TypeScript nullとundefinedどちらを使う？](https://zenn.dev/saki/articles/48425da2f1e8a0)
- ローディング中は後々ロードを用意するとして、ログインしていない場合は`/accout`にリダイレクトさせるようにした

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
ログインしている状態で/account以外のページにアクセスしてみる

# チェックリスト
- [x] PRに必要な内容を記述し、Assignやタイトルを設定した
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [x] PCで見た時に表示が崩れていないことを確認した
  - [x] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
