### PR TITLE
FirestoreとStorageのセキュリティを設定

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,17 @@
     "browser": true,
     "es2021": true
   },
-  "extends": ["plugin:react/recommended", "prettier", "next", "next/core-web-vitals", "eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:@typescript-eslint/stylistic", "plugin:react-hooks/recommended", "plugin:@next/next/recommended"],
+  "extends": [
+    "plugin:react/recommended",
+    "prettier",
+    "next",
+    "next/core-web-vitals",
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/stylistic",
+    "plugin:react-hooks/recommended",
+    "plugin:@next/next/recommended"
+  ],
   "overrides": [
     {
       "env": {

--- a/firebase.json
+++ b/firebase.json
@@ -35,7 +35,8 @@
       "port": 5001
     },
     "firestore": {
-      "port": 8081
+      "port": 8081,
+      "rules": "firestore.rules"
     },
     "database": {
       "port": 9001

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,17 +3,15 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // This rule allows anyone with your Firestore database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
     match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2024, 12, 6);
+      // read: ログイン中のユーザーのみ
+      allow read: if request.auth != null;
+
+      // write: ログイン中でゲストでないユーザー(メール、Google)のみ
+      allow write: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
     }
   }
 }
+
+// 以下のコマンドで本番環境にも適用
+// firebase deploy --only firestore:rules

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,11 +4,12 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     match /{document=**} {
-      // read: ログイン中のユーザーのみ
+      // 読み取り: ログイン中のユーザーのみ許可
       allow read: if request.auth != null;
 
-      // write: ログイン中でゲストでないユーザー(メール、Google)のみ
-      allow write: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
+      // 書き込み: ログイン中でゲストでないユーザー（メール、Google）のみ許可
+      allow write: if request.auth != null &&
+                    request.auth.token.firebase.sign_in_provider != 'anonymous';
     }
   }
 }

--- a/src/Components/PostModal/PostModal.tsx
+++ b/src/Components/PostModal/PostModal.tsx
@@ -39,7 +39,27 @@ export default function PostModal({ goalId }: { goalId: string }) {
 
   const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     const selectedFile = event.target.files?.[0];
-    if (selectedFile && !selectedFile.type.startsWith("image/")) {
+
+    if (!selectedFile) {
+      showSnackBar({
+        message: "ファイルが選択されていません",
+        type: "warning",
+      });
+      return;
+    }
+
+    // ファイルサイズの上限を設定
+    const maxSize = 8; // 上限8MB
+    const fileSizeMB = selectedFile.size / (1024 * 1024);
+    if (fileSizeMB > maxSize) {
+      showSnackBar({
+        message: `最大ファイルサイズは${maxSize}MBです。`,
+        type: "warning",
+      });
+      return;
+    }
+
+    if (!selectedFile.type.startsWith("image/")) {
       showSnackBar({
         message: "画像ファイルのみアップロードできます",
         type: "warning",

--- a/src/app/firebase.ts
+++ b/src/app/firebase.ts
@@ -38,37 +38,37 @@ if (typeof window !== "undefined") {
   messaging = getMessaging(app);
   analytics = getAnalytics(app);
 
-  // 開発環境とステージング環境でApp Checkのデバッグトークンを有効にする
-  if (
-    typeof window !== "undefined" &&
-    (process.env.NODE_ENV === "development" ||
-      process.env.NEXT_PUBLIC_IS_STAGING === "true")
-  ) {
-    (
-      window as unknown as { FIREBASE_APPCHECK_DEBUG_TOKEN: boolean }
-    ).FIREBASE_APPCHECK_DEBUG_TOKEN = true;
-    console.log("App Check Debug Token Enabled");
-  }
-  // App Checkの設定
-  const appCheck = initializeAppCheck(app, {
-    provider: new ReCaptchaV3Provider(
-      process.env.NEXT_PUBLIC_FIREBASE_RECAPTCHA_SITEKEY as string
-    ),
-    isTokenAutoRefreshEnabled: true,
-  });
-  getToken(appCheck)
-    .then((token) => {
-      console.log("App Check: Success");
-      appCheckToken = token.token;
-    })
-    .catch((error) => {
-      console.log("App Check error:", error.message);
-      showSnackBar({
-        message:
-          "App Checkの初期化に失敗しました。debug tokenがサーバーに登録されていることを確認してください。",
-        type: "warning",
-      });
+  // 開発環境ならApp Checkを使用しない
+  // ステージング環境でApp Checkのデバッグトークンを有効にする
+  if (process.env.NODE_ENV !== "development") {
+    if (process.env.NEXT_PUBLIC_IS_STAGING === "true") {
+      (
+        window as unknown as { FIREBASE_APPCHECK_DEBUG_TOKEN: boolean }
+      ).FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+      console.log("App Check Debug Token Enabled");
+    }
+    // App Checkの設定
+    const appCheck = initializeAppCheck(app, {
+      provider: new ReCaptchaV3Provider(
+        process.env.NEXT_PUBLIC_FIREBASE_RECAPTCHA_SITEKEY as string
+      ),
+      isTokenAutoRefreshEnabled: true,
     });
+
+    getToken(appCheck)
+      .then((token) => {
+        console.log("App Check: Success");
+        appCheckToken = token.token;
+      })
+      .catch((error) => {
+        console.log(error.message);
+        showSnackBar({
+          message:
+            "App Checkの初期化に失敗しました。debug tokenがサーバーに登録されていることを確認してください。",
+          type: "warning",
+        });
+      });
+  }
 }
 
 export const googleProvider = new GoogleAuthProvider();

--- a/storage.rules
+++ b/storage.rules
@@ -1,8 +1,17 @@
 rules_version = '2';
+
 service firebase.storage {
   match /b/{bucket}/o {
-    match /post/{documentId} {
-      allow read, write: if true;
+
+    match /{allPaths=**} {
+      // read: ログイン中のユーザーのみ
+      allow read: if request.auth != null;
+
+      // write: ログイン中でゲストでないユーザー(メール、Google)のみ
+      allow write: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
     }
   }
 }
+
+// 以下のコマンドで本番環境にも適用
+// firebase deploy --only storage

--- a/storage.rules
+++ b/storage.rules
@@ -4,11 +4,16 @@ service firebase.storage {
   match /b/{bucket}/o {
 
     match /{allPaths=**} {
-      // read: ログイン中のユーザーのみ
+      // 読み取り: ログイン中のユーザーのみ許可
       allow read: if request.auth != null;
 
-      // write: ログイン中でゲストでないユーザー(メール、Google)のみ
-      allow write: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
+      // 書き込み: ログイン中でゲストでないユーザー（メール、Google）かつ、画像ファイルのみ許可
+      // 制限: 画像ファイルのみ, 最大容量は8MB
+      allow write: if request.auth != null &&
+                    request.auth.token.firebase.sign_in_provider != 'anonymous' &&
+                    (request.resource.contentType.matches('image/.*') ||
+                    request.resource.contentType == 'image/webp') &&
+                    request.resource.size < 8 * 1024 * 1024;
     }
   }
 }


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [storageへのDOS対策](https://github.com/MurakawaTakuya/todo-real/issues/63)

## 概要
<!-- 変更内容を簡単に説明 -->
FirestoreとStorageのセキュリティを設定

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- FirestoreとStorageのrulesを設定
  - read: ログイン中のユーザーのみ(Google, Mail, Guest)
  - write: Guest以外のログイン中のユーザーのみ
- Storageへのアップロード制限
  - 以下の制限をフロントエンド・バックエンド(rules)に設定
    - ファイルの容量を最大3MBに制限
      <img src="https://github.com/user-attachments/assets/76d9934a-6e67-4856-a99a-809a4797b4ae" width="400" />
    - 画像のみに制限

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
Postman等でStorageやFirestoreを叩いてみる

# チェックリスト
- [x] PRに必要な内容を記述し、Assignやタイトルを設定した
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
