### PR TITLE
navigation menu作成

### DIFF
--- a/src/Components/NavigationMenu/NavigationMenu.tsx
+++ b/src/Components/NavigationMenu/NavigationMenu.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useUser } from "@/utils/UserContext";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import HomeRoundedIcon from "@mui/icons-material/HomeRounded";
 import Person from "@mui/icons-material/Person";
@@ -25,7 +24,6 @@ export default function NavigationMenu() {
     : 2;
   const [index, setIndex] = useState(defaultIndex);
   const colors = ["success", "primary", "warning"] as const;
-  const { user } = useUser();
 
   useEffect(() => {
     if (document.readyState === "complete") {
@@ -42,10 +40,13 @@ export default function NavigationMenu() {
         borderTopLeftRadius: "12px",
         borderTopRightRadius: "12px",
         bgcolor: `${"var(--colors-index)"}.500`,
-        position: "sticky",
+        position: "fixed",
         bottom: "30px",
+        width: "100%",
+        maxWidth: "600px",
+        zIndex: 100,
       }}
-      style={{ "--colors-index": colors[index] } as any}
+      style={{ "--colors-index": colors[index] } as React.CSSProperties}
     >
       <Tabs
         size="lg"
@@ -55,7 +56,7 @@ export default function NavigationMenu() {
         sx={(theme) => ({
           p: 1,
           borderRadius: 16,
-          maxWidth: 500,
+          maxWidth: "93%",
           mx: "auto",
           boxShadow: theme.shadow.sm,
           "--joy-shadowChannel": theme.vars.palette[colors[index]].darkChannel,
@@ -80,8 +81,8 @@ export default function NavigationMenu() {
           <Tab
             disableIndicator
             orientation="vertical"
+            sx={{ margin: "0 3px", padding: "8px 0 !important" }}
             {...(index === 0 && { color: colors[0] })}
-            disabled={!user}
           >
             <ListItemDecorator>
               <FormatListBulletedIcon />
@@ -91,8 +92,8 @@ export default function NavigationMenu() {
           <Tab
             disableIndicator
             orientation="vertical"
+            sx={{ margin: "0 3px", padding: "8px 0 !important" }}
             {...(index === 1 && { color: colors[1] })}
-            disabled={!user}
           >
             <ListItemDecorator>
               <HomeRoundedIcon />
@@ -102,6 +103,7 @@ export default function NavigationMenu() {
           <Tab
             disableIndicator
             orientation="vertical"
+            sx={{ margin: "0 3px", padding: "8px 0 !important" }}
             {...(index === 2 && { color: colors[2] })}
           >
             <ListItemDecorator>

--- a/src/Components/NavigationMenu/NavigationMenu.tsx
+++ b/src/Components/NavigationMenu/NavigationMenu.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useUser } from "@/utils/UserContext";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import HomeRoundedIcon from "@mui/icons-material/HomeRounded";
 import Person from "@mui/icons-material/Person";
@@ -7,17 +8,37 @@ import ListItemDecorator from "@mui/joy/ListItemDecorator";
 import Tab, { tabClasses } from "@mui/joy/Tab";
 import TabList from "@mui/joy/TabList";
 import Tabs from "@mui/joy/Tabs";
-import { useState } from "react";
+import { redirect } from "next/navigation";
+import { useEffect, useState } from "react";
 
 export default function NavigationMenu() {
-  const [index, setIndex] = useState(0);
+  const paths = [
+    ["/mycontent", "/mycontent/"],
+    ["/"],
+    ["/account", "/account/"],
+  ];
+  const pathname = window.location.pathname;
+  const defaultIndex = paths[0].some((path) => path === pathname)
+    ? 0
+    : paths[1].some((path) => path === pathname)
+    ? 1
+    : 2;
+  const [index, setIndex] = useState(defaultIndex);
   const colors = ["success", "primary", "warning"] as const;
+  const { user } = useUser();
+
+  useEffect(() => {
+    if (document.readyState === "complete") {
+      if (!paths[index].some((path) => path === pathname)) {
+        redirect(paths[index][0]);
+      }
+    }
+  }, [index]);
+
   return (
     <Box
       sx={{
         flexGrow: 1,
-        // m: -3,
-        // p: 4,
         borderTopLeftRadius: "12px",
         borderTopRightRadius: "12px",
         bgcolor: `${"var(--colors-index)"}.500`,
@@ -60,6 +81,7 @@ export default function NavigationMenu() {
             disableIndicator
             orientation="vertical"
             {...(index === 0 && { color: colors[0] })}
+            disabled={!user}
           >
             <ListItemDecorator>
               <FormatListBulletedIcon />
@@ -70,6 +92,7 @@ export default function NavigationMenu() {
             disableIndicator
             orientation="vertical"
             {...(index === 1 && { color: colors[1] })}
+            disabled={!user}
           >
             <ListItemDecorator>
               <HomeRoundedIcon />

--- a/src/Components/NavigationMenu/NavigationMenu.tsx
+++ b/src/Components/NavigationMenu/NavigationMenu.tsx
@@ -1,0 +1,93 @@
+"use client";
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
+import HomeRoundedIcon from "@mui/icons-material/HomeRounded";
+import Person from "@mui/icons-material/Person";
+import Box from "@mui/joy/Box";
+import ListItemDecorator from "@mui/joy/ListItemDecorator";
+import Tab, { tabClasses } from "@mui/joy/Tab";
+import TabList from "@mui/joy/TabList";
+import Tabs from "@mui/joy/Tabs";
+import { useState } from "react";
+
+export default function NavigationMenu() {
+  const [index, setIndex] = useState(0);
+  const colors = ["success", "primary", "warning"] as const;
+  return (
+    <Box
+      sx={{
+        flexGrow: 1,
+        // m: -3,
+        // p: 4,
+        borderTopLeftRadius: "12px",
+        borderTopRightRadius: "12px",
+        bgcolor: `${"var(--colors-index)"}.500`,
+        position: "sticky",
+        bottom: "30px",
+      }}
+      style={{ "--colors-index": colors[index] } as any}
+    >
+      <Tabs
+        size="lg"
+        aria-label="Bottom Navigation"
+        value={index}
+        onChange={(event, value) => setIndex(value as number)}
+        sx={(theme) => ({
+          p: 1,
+          borderRadius: 16,
+          maxWidth: 500,
+          mx: "auto",
+          boxShadow: theme.shadow.sm,
+          "--joy-shadowChannel": theme.vars.palette[colors[index]].darkChannel,
+          [`& .${tabClasses.root}`]: {
+            py: 1,
+            flex: 1,
+            transition: "0.3s",
+            fontWeight: "md",
+            fontSize: "md",
+            [`&:not(.${tabClasses.selected}):not(:hover)`]: {
+              opacity: 0.7,
+            },
+          },
+        })}
+      >
+        <TabList
+          variant="plain"
+          size="sm"
+          disableUnderline
+          sx={{ borderRadius: "lg", p: 0 }}
+        >
+          <Tab
+            disableIndicator
+            orientation="vertical"
+            {...(index === 0 && { color: colors[0] })}
+          >
+            <ListItemDecorator>
+              <FormatListBulletedIcon />
+            </ListItemDecorator>
+            My contents
+          </Tab>
+          <Tab
+            disableIndicator
+            orientation="vertical"
+            {...(index === 1 && { color: colors[1] })}
+          >
+            <ListItemDecorator>
+              <HomeRoundedIcon />
+            </ListItemDecorator>
+            Homes
+          </Tab>
+          <Tab
+            disableIndicator
+            orientation="vertical"
+            {...(index === 2 && { color: colors[2] })}
+          >
+            <ListItemDecorator>
+              <Person />
+            </ListItemDecorator>
+            Profile
+          </Tab>
+        </TabList>
+      </Tabs>
+    </Box>
+  );
+}

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -26,7 +26,7 @@ const Card = styled(MuiCard)(({ theme }) => ({
   width: "100%",
   padding: theme.spacing(4),
   gap: theme.spacing(2),
-  margin: "auto",
+  margin: "0 auto",
   boxShadow:
     "hsla(220, 30%, 5%, 0.05) 0px 5px 15px 0px, hsla(220, 25%, 10%, 0.05) 0px 15px 35px -5px",
   borderRadius: "20px",
@@ -96,7 +96,7 @@ export default function Account() {
         direction="column"
         justifyContent="center"
         alignItems="center"
-        sx={{ height: "100vh", padding: 2 }}
+        sx={{ padding: 2 }}
       >
         <Card variant="outlined">
           <Typography variant="h4" textAlign="center">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import Header from "@/Components/Header/Header";
+import NavigationMenu from "@/Components/NavigationMenu/NavigationMenu";
 import { TopPage } from "@/Components/TopPage/TopPage";
 import "@/styles/globals.scss";
 import "@/utils/CloudMessaging/getNotification";
@@ -27,7 +28,10 @@ export default function RootLayout({
       <body>
         <Header />
         <UserProvider>
-          <TopPage>{children}</TopPage>
+          <TopPage>
+            {children}
+            <NavigationMenu />
+          </TopPage>
         </UserProvider>
       </body>
     </html>

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -15,9 +15,9 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji" !important;
-  height: 100vh;
   margin: 0 auto !important;
-  max-width: 700px;
+  max-width: 600px;
+  min-height: 100vh;
 }
 
 main {

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -22,4 +22,5 @@ body {
 
 main {
   background: white;
+  padding-bottom: 130px;
 }


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [navigation menu作成](https://github.com/MurakawaTakuya/todo-real/issues/79)

## 概要
<!-- 変更内容を簡単に説明 -->
navigation menu作成

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
参考: [Mobile bottom navigation](https://mui.com/joy-ui/react-tabs/#mobile-bottom-navigation)
サンプル: https://codesandbox.io/embed/5rttf2?module=/src/Demo.tsx&fontsize=12

以下のようにしてログインしていない場合はアカウントボタン以外を押せないようにしたかったが、アカウント情報が更新した時にJoy UIがバグるのでやめた
おそらくindexの値がdisabledがある場合とない場合でずれているため
https://github.com/MurakawaTakuya/todo-real/blob/5acf6dd151ce76096c0e22d559d7658a04c90e1b/src/Components/NavigationMenu/NavigationMenu.tsx#L84
![image](https://github.com/user-attachments/assets/ac26d87b-037a-41ad-86ef-3c7dd7075c43)



## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [x] PRに必要な内容を記述し、Assignやタイトルを設定した
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [x] PCで見た時に表示が崩れていないことを確認した
  - [x] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
