### PR TITLE
アカウントが認証されている場合のみ他の人の目標をコピーするボタンを表示するように変更

### DIFF
--- a/src/Components/Account/LoggedInView.tsx
+++ b/src/Components/Account/LoggedInView.tsx
@@ -51,6 +51,26 @@ export default function LoggedInView() {
           <Typography level="body-lg" sx={{ textAlign: "center" }}>
             ようこそ、{user.name}さん!
           </Typography>
+        </>
+      )}
+
+      {!user.isMailVerified && (
+        <Typography color="danger">
+          メールに届いた認証リンクを確認してください。
+          認証が完了するまで閲覧以外の機能は使用できません。
+        </Typography>
+      )}
+
+      {user.loginType === "Guest" && (
+        <Typography color="danger">
+          ゲストユーザーは閲覧以外の機能は使用できません。
+          全ての機能を利用するにはログインが必要です。
+        </Typography>
+      )}
+
+      {/* ゲストかメール未認証の場合は閲覧以外の機能を使用できなくする */}
+      {user.loginType !== "Guest" && user.isMailVerified && (
+        <>
           <div style={{ display: "flex", flexDirection: "column", gap: "3px" }}>
             <Typography level="title-md" sx={{ textAlign: "center" }}>
               連続達成日数: {userStats.streak}日目
@@ -62,26 +82,6 @@ export default function LoggedInView() {
               達成回数: {userStats.completed}回
             </Typography>
           </div>
-        </>
-      )}
-
-      {!user.isMailVerified && (
-        <Typography color="danger">
-          メールに届いた認証リンクを確認してください。
-          認証が完了するまで閲覧以外の機能は制限されます。
-        </Typography>
-      )}
-
-      {user.loginType === "Guest" && (
-        <Typography color="danger">
-          ゲストユーザーは閲覧以外の機能は制限されます。
-          全ての機能を利用するにはログインが必要です。
-        </Typography>
-      )}
-
-      {/* ゲストかメール未認証の場合は名前の変更や通知の使用をできないようにする */}
-      {user.loginType !== "Guest" && user.isMailVerified && (
-        <>
           <div style={{ display: "flex", justifyContent: "space-evenly" }}>
             <NameUpdate />
             <NotificationButton />

--- a/src/Components/Progress/Progress.tsx
+++ b/src/Components/Progress/Progress.tsx
@@ -379,7 +379,9 @@ const GoalCard = ({
             {formatStringToDate(deadline)}までに
           </Typography>
           <div style={{ display: "flex", gap: "5px" }}>
-            <CopyModalButton deadline={deadline} goalText={goalText} />
+            {user.loginType !== "Guest" && user.isMailVerified && (
+              <CopyModalButton deadline={deadline} goalText={goalText} />
+            )}
             {/* 期限の1時間以内、もしくは自分の目標ではない場合は削除できないようにする */}
             {!isWithinOneHour && userId === user?.userId && (
               <DeleteGoalModal goalId={goalId} />

--- a/src/app/mycontent/page.tsx
+++ b/src/app/mycontent/page.tsx
@@ -2,6 +2,7 @@
 import DashBoard from "@/Components/DashBoard/DashBoard";
 import GoalModalButton from "@/Components/GoalModal/GoalModalButton";
 import { useUser } from "@/utils/UserContext";
+import Typography from "@mui/joy/Typography";
 import { styled } from "@mui/material/styles";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
@@ -44,7 +45,23 @@ export default function MyContent() {
         </CenteredToggleButtonGroup>
       </div>
 
-      {value === "pending" ? (
+      {user?.loginType === "Guest" ? (
+        <Typography
+          level="body-md"
+          color="danger"
+          sx={{ textAlign: "center", marginTop: "20px" }}
+        >
+          ゲストログインでは投稿を作成できません。
+        </Typography>
+      ) : !user?.isMailVerified ? (
+        <Typography
+          level="body-md"
+          color="danger"
+          sx={{ textAlign: "center", marginTop: "20px" }}
+        >
+          メールに届いた認証リンクを確認してください。
+        </Typography>
+      ) : value === "pending" ? (
         <DashBoard
           key="pending"
           userId={user?.userId}


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [他の人の目標のコピーを認証されたユーザーのみが使えるようにする](https://github.com/MurakawaTakuya/todo-real/issues/137)

## 概要
<!-- 変更内容を簡単に説明 -->
アカウントが認証されている場合のみ他の人の目標をコピーするボタンを表示するように変更
<img src="https://github.com/user-attachments/assets/63f446ef-c58f-452b-b85d-fe975b656083" width="400">

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- アカウントが認証されている場合のみ他の人の目標をコピーするボタンを表示するように変更
- その他認証状態に応じて表示を変更

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [ ] PRに必要な内容を記述し、Assignやタイトルを設定した
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
