### PR TITLE
目標完了時にCloud Tasksの通知が削除されない問題を修正

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -115,7 +115,7 @@ export const firestore = onRequest({ region: region }, async (req, res) => {
 export {
   createTasksOnGoalCreate,
   deleteTasksOnGoalDelete,
-  deleteTasksOnPostCreate,
+  updateTasksOnPostUpdate,
 } from "./tasks";
 
 // テスト用API

--- a/functions/src/tasks.ts
+++ b/functions/src/tasks.ts
@@ -11,6 +11,60 @@ const tasksClient = new CloudTasksClient();
 const projectId = process.env.GCP_PROJECT_ID;
 const region = "asia-northeast1";
 const queue = "deadline-notification-queue";
+const marginTime = 10;
+
+// queuePath, postData, etaを受け取り、タスクを作成
+const createTask = async (
+  queuePath: string,
+  postData: { goalId: string; marginTime: number },
+  eta: Date
+) => {
+  const accessToken = process.env.NOTIFICATION_KEY;
+  const goalId = postData.goalId;
+
+  const now = new Date();
+  // タスクの名前をgoalIdと作成日時を結合したものに設定
+  const name = `${queuePath}/tasks/${goalId}-${now.getTime()}`;
+  logger.info(`Creating task: ${name}`);
+  await tasksClient.createTask({
+    parent: queuePath,
+    task: {
+      name,
+      httpRequest: {
+        httpMethod: "POST",
+        url: "https://firestore-okdtj725ta-an.a.run.app/notification",
+        headers: {
+          "Content-Type": "application/json",
+          token: `${accessToken}`,
+        },
+        body: Buffer.from(JSON.stringify(postData)).toString("base64"),
+      },
+      scheduleTime: { seconds: Math.floor(eta.getTime() / 1000) },
+    },
+  });
+  logger.info(`Task created for ${goalId} with ${name}`);
+};
+
+// queuePath, goalIdで始まるタスクを削除
+const deleteTask = async (queuePath: string, goalId: string) => {
+  const taskPrefix = `${queuePath}/tasks/${goalId}`;
+  logger.info(`Deleting tasks for ${goalId} with prefix ${taskPrefix}`);
+
+  const [tasks] = await tasksClient.listTasks({ parent: queuePath });
+  const tasksToDelete = tasks.filter(
+    (task) => task.name && task.name.startsWith(taskPrefix)
+  );
+
+  for (const task of tasksToDelete) {
+    if (task.name) {
+      logger.info("Deleting task:", task.name);
+      await tasksClient.deleteTask({ name: task.name });
+      logger.info("Task deleted:", task.name);
+    }
+  }
+
+  logger.info("All tasks with prefix deleted for goalId:", goalId);
+};
 
 export const createTasksOnGoalCreate = onDocumentCreated(
   { region: region, document: "goal/{goalId}" },
@@ -32,38 +86,113 @@ export const createTasksOnGoalCreate = onDocumentCreated(
 
     try {
       const goalData = event.data.data();
-      const marginTime = 10;
+      const postData = {
+        goalId: event.params.goalId,
+        marginTime,
+      };
       // 期限のmarginTime分前にタスクを設定
       const deadline = new Date(
         goalData.deadline.toDate().getTime() - marginTime * 60 * 1000
       );
-      const goalId = event.params.goalId;
-      const postData = {
-        goalId,
-        marginTime,
-      };
-      const queuePath = tasksClient.queuePath(projectId, region, queue);
-      const accessToken = process.env.NOTIFICATION_KEY;
-
-      await tasksClient.createTask({
-        parent: queuePath,
-        task: {
-          name: `${queuePath}/tasks/${goalId}`, // タスクの名前をgoalIdに設定
-          httpRequest: {
-            httpMethod: "POST",
-            url: "https://firestore-okdtj725ta-an.a.run.app/notification",
-            headers: {
-              "Content-Type": "application/json",
-              token: `${accessToken}`,
-            },
-            body: Buffer.from(JSON.stringify(postData)).toString("base64"),
-          },
-          scheduleTime: { seconds: Math.floor(deadline.getTime() / 1000) },
-        },
-      });
-      logger.info("Task created for goalId:", goalId);
+      createTask(
+        tasksClient.queuePath(projectId, region, queue),
+        postData,
+        deadline
+      );
     } catch (error) {
       logger.error("Error scheduling task:", error);
+    }
+  }
+);
+
+// 目標を完了した時にtasksから通知予定を削除する
+export const updateTasksOnPostUpdate = onDocumentUpdated(
+  {
+    region: region,
+    document: "goal/{goalId}",
+  },
+  async (event) => {
+    if (process.env.NODE_ENV !== "production") {
+      return;
+    }
+
+    if (!projectId) {
+      logger.error("GCP_PROJECT_ID is not defined.");
+      return;
+    }
+
+    if (!event.data) {
+      logger.error("No data found in event.");
+      return;
+    }
+
+    if (
+      event.data.before.data().post === null &&
+      event.data.after.data().post !== null
+    ) {
+      // 目標を完了(完了投稿を作成)した場合
+      // null -> post に変更された場合はタスクを削除
+      try {
+        const goalId = event.params.goalId;
+        const queuePath = tasksClient.queuePath(projectId, region, queue);
+        await deleteTask(queuePath, goalId);
+      } catch (error) {
+        logger.error("Error deleting task:", error);
+      }
+    } else if (
+      event.data.before.data().post !== null &&
+      event.data.after.data().post === null
+    ) {
+      // 完了投稿を削除した場合
+      // post -> null に変更された場合はタスクを作成(deadlineが今よりも後の場合のみ)
+      if (
+        event.data.after.data().deadline.toDate().getTime() <=
+        new Date().getTime()
+      ) {
+        return;
+      }
+
+      // taskを作成
+      try {
+        const postData = {
+          goalId: event.params.goalId,
+          marginTime,
+        };
+        createTask(
+          tasksClient.queuePath(projectId, region, queue),
+          postData,
+          event.data.after.data().deadline.toDate()
+        );
+      } catch (error) {
+        logger.error("Error scheduling task:", error);
+      }
+    } else if (
+      event.data.before.data().post === null &&
+      event.data.after.data().post === null
+    ) {
+      // deadlineが変更された場合はタスクを削除して再作成
+      if (event.data.before.data() === event.data.after.data()) {
+        return;
+      }
+      try {
+        // taskを削除
+        const goalId = event.params.goalId;
+        const queuePath = tasksClient.queuePath(projectId, region, queue);
+        await deleteTask(queuePath, goalId);
+
+        const postData = {
+          goalId: event.params.goalId,
+          marginTime,
+        };
+        // taskを作成
+        createTask(
+          queuePath,
+          postData,
+          event.data.after.data().deadline.toDate()
+        );
+      } catch (error) {
+        logger.error("Error updating task:", error);
+      }
     }
   }
 );
@@ -89,46 +218,7 @@ export const deleteTasksOnGoalDelete = onDocumentDeleted(
     try {
       const goalId = event.params.goalId;
       const queuePath = tasksClient.queuePath(projectId, region, queue);
-      const taskName = `${queuePath}/tasks/${goalId}`; // goalIdが名前になっているタスクを削除
-      await tasksClient.deleteTask({ name: taskName });
-      logger.info("Task deleted for goalId:", goalId);
-    } catch (error) {
-      logger.error("Error deleting task:", error);
-    }
-  }
-);
-
-// 目標を完了した時にtasksから通知予定を削除する
-export const deleteTasksOnPostCreate = onDocumentUpdated(
-  {
-    region: region,
-    document: "goal/{goalId}",
-  },
-  async (event) => {
-    if (process.env.NODE_ENV !== "production") {
-      return;
-    }
-
-    if (!projectId) {
-      logger.error("GCP_PROJECT_ID is not defined.");
-      return;
-    }
-
-    if (!event.data) {
-      logger.error("No data found in event.");
-      return;
-    }
-
-    if (event.data.after.data().post !== null) {
-      return;
-    }
-
-    try {
-      const goalId = event.params.goalId;
-      const queuePath = tasksClient.queuePath(projectId, region, queue);
-      const taskName = `${queuePath}/tasks/${goalId}`; // goalIdが名前になっているタスクを削除
-      await tasksClient.deleteTask({ name: taskName });
-      logger.info("Task deleted for goalId:", goalId);
+      await deleteTask(queuePath, goalId);
     } catch (error) {
       logger.error("Error deleting task:", error);
     }


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

- Close #172

## 概要
<!-- 変更内容を簡単に説明 -->
目標完了時にCloud Tasksの通知が削除されない問題を修正
同時に以下の機能も実装
- 期限を変更した時に通知送信時間を更新
- 完了投稿だけを削除した時に通知を再度登録

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- 目標完了時にCloud Tasksの通知が削除されない問題を修正
  条件文とパスのミス
  ```
    Error deleting task: Error: 5 NOT_FOUND: Requested entity was not found.
  ```
- 期限を変更した時に通知送信時間を変更
  期限を変更したら、通知を再設定するためにCloud tasksにHTTPリクエストを再設定しようとしたが以下のエラーのように、同じ名前のtaskをすぐに再作成することができないようだったので、goalIdの後ろに作成時間のDate型の数値をつけることで一意にする。また、削除時はgoalIdで始まるtaskを探して削除するようにした。
  ```
  Exception from a finished function: Error: 6 ALREADY_EXISTS: The task cannot be created because a task with this name existed too recently. For more information about task de-duplication see https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks/create#body.request_body.FIELDS.task.
  ```
  ![image](https://github.com/user-attachments/assets/43e0daec-0c39-49b7-8edd-9066011e645d)

現状目標と完了投稿の状態が変わった場合の処理は次の通り
- 目標
  - 作成: `createTasksOnGoalCreate`でtask作成
  - 削除: `deleteTasksOnGoalDelete`でtask削除
  - 期限変更: `updateTasksOnPostUpdate`でtask削除・作成
- 完了投稿
  - 作成: `updateTasksOnPostUpdate`でtask削除
  - 削除: `updateTasksOnPostUpdate`でtask作成

- `deleteTasksOnPostCreate`を`updateTasksOnPostUpdate`に変更した

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [x] PRに必要な内容を記述し、Assignやタイトルを設定した
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
